### PR TITLE
New Druid mirror host

### DIFF
--- a/aqs-docker-druid-test-env-build/Dockerfile
+++ b/aqs-docker-druid-test-env-build/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
     && apt-get install -y --no-install-recommends netcat \
     && rm -rf /var/lib/apt/lists/* \
-    && curl --output $DRUID_ARCHIVE https://mirrors.ocf.berkeley.edu/apache/druid/$DRUID_VERSION/$DRUID_ARCHIVE \
+    && curl --output $DRUID_ARCHIVE https://archive.apache.org/dist/druid/$DRUID_VERSION/$DRUID_ARCHIVE \
     && tar -xzf $DRUID_ARCHIVE \
     && rm $DRUID_ARCHIVE \
     && rm -rf $DRUID_DIR/extensions \


### PR DESCRIPTION
Updated Dockerfile with a new Druid mirror host. The previous one seems to be down